### PR TITLE
Adding a fix for the FieldService setting for generating new Scratch …

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -16,5 +16,5 @@
         "fieldServiceOrgPref": true
       }
   },
-  "features": ["PlatformEncryption", "Communities", "WorkplaceCommandCenterUser", "ForceComPlatform", "ServiceCloud", "FieldService"]
+  "features": ["PlatformEncryption", "Communities", "WorkplaceCommandCenterUser", "ForceComPlatform", "ServiceCloud", "FieldService:2"]
 }


### PR DESCRIPTION
…Org in Winter 2021

Your repo will generate an error if you try to `sfdx force:org:create` with your current config file. I added a license count of 2 to get past the following error;

```
ERROR running force:org:create:  The feature value FieldService requires a quantity.
```